### PR TITLE
Update README.md with instructions to install on ST3

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,10 @@ CFEngine configuration file beautifier written in Python. It can be used standal
 #### Command Line Options
 
 Run cf-beautify --help
+
+#### Installation
+
+##### Manual Install with ST3
+cd ~/.config/sublime-text-3/Packages
+git clone https://github.com/naksu/cfengine_beautifier.git CFEngineBeautifier
+


### PR DESCRIPTION
If installing manually you need to check out to `CFEngineBeautifier` or the default settings will not appear when accessed from the menu (though the defaults are still in effect).
